### PR TITLE
Adding the optional product pathId param

### DIFF
--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -43,6 +43,7 @@ resource "controltower_aws_account" "account" {
 ### Optional
 
 - **id** (String) The ID of this resource.
+- **path_id** (String) Name of the path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths.
 - **provisioned_product_name** (String) Name of the service catalog product that is provisioned. Defaults to a slugified version of the account name.
 - **tags** (Map of String) Key-value map of resource tags for the account.
 


### PR DESCRIPTION
Hi! I ran into this error when attempting to create an account:
```
Error: error provisioning account live: InvalidParametersException: More than one launch path ids exist. Please specify the launch path id
│ 
│   with controltower_aws_account.shared,
│   on env-aws.tf line 17, in resource "controltower_aws_account" "shared":
│   17: resource "controltower_aws_account" "shared" {
│ 
```

In the last 2 or 3 weeks something changed and now I have two of these "launch paths" assigned to my `AWS Control Tower Account Factory` product in Service Catalog, and both are the same empty config. 

```
 ➜ aws servicecatalog list-launch-paths --product-id prod-123456
{
    "LaunchPathSummaries": [
        {
            "Id": "lpv2-123456",
            "ConstraintSummaries": [],
            "Tags": [],
            "Name": "AWS Control Tower Account Factory Portfolio"
        },
        {
            "Id": "lpv2-123123",
            "ConstraintSummaries": [],
            "Tags": [],
            "Name": "AWS Control Tower Account Factory Portfolio"
        }
    ]
}
```

Once you have more than one of these it is required to supply one of them in the request

aws docs
> The path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths. You must provide the name or ID, but not both.

There doesn't appear to be a way to remove these launch paths, I guess that is controlled by Control Tower. So after I applied this patch I was able to supply one of these launch path IDs and get my deployment completed.

thanks!