### PR TITLE
feat: add options for automating account closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 You can browse documentation on the [Terraform provider registry](https://registry.terraform.io/providers/idealo/controltower/latest/docs).
 
-## Using the provider
+## Developing the Provider
 
-You can use the provider via the [Terraform provider registry](https://registry.terraform.io/providers/idealo/controltower).
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine.
+
+To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+
+To generate or update documentation, run `go generate`.
+
+In order to run the full suite of Acceptance tests, run `make testacc`.
+
+*Note:* Acceptance tests create real resources, and often cost money to run.
+
+```sh
+$ make testacc
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,31 +33,31 @@ provider "controltower" {
 
 ### Required
 
-- **region** (String) This is the AWS region. It must be provided, but it can also be sourced from the `AWS_DEFAULT_REGION` environment variables, or via a shared credentials file if `profile` is specified.
+- `region` (String) This is the AWS region. It must be provided, but it can also be sourced from the `AWS_DEFAULT_REGION` environment variables, or via a shared credentials file if `profile` is specified.
 
 ### Optional
 
-- **access_key** (String) This is the AWS access key. It must be provided, but it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, or via a shared credentials file if `profile` is specified.
-- **assume_role** (Block List, Max: 1) Settings for making use of the AWS Assume Role functionality. (see [below for nested schema](#nestedblock--assume_role))
-- **max_retries** (Number) This is the maximum number of times an API call is retried, in the case where requests are being throttled or experiencing transient failures. The delay between the subsequent API calls increases exponentially. If omitted, the default value is `25`.
-- **profile** (String) This is the AWS profile name as set in the shared credentials file.
-- **secret_key** (String) This is the AWS secret key. It must be provided, but it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, or via a shared credentials file if `profile` is specified.
-- **shared_credentials_file** (String) This is the path to the shared credentials file. If this is not set and a profile is specified, `~/.aws/credentials` will be used.
-- **skip_credentials_validation** (Boolean) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented.
-- **skip_metadata_api_check** (Boolean) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. Setting to `true` prevents Terraform from authenticating via the Metadata API. You may need to use other authentication methods like static credentials, configuration variables, or environment variables.
-- **skip_requesting_account_id** (Boolean) Skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
-- **token** (String) Session token for validating temporary credentials. Typically provided after successful identity federation or Multi-Factor Authentication (MFA) login. With MFA login, this is the session token provided afterward, not the 6 digit MFA code used to get temporary credentials. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
+- `access_key` (String) This is the AWS access key. It must be provided, but it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, or via a shared credentials file if `profile` is specified.
+- `assume_role` (Block List, Max: 1) Settings for making use of the AWS Assume Role functionality. (see [below for nested schema](#nestedblock--assume_role))
+- `max_retries` (Number) This is the maximum number of times an API call is retried, in the case where requests are being throttled or experiencing transient failures. The delay between the subsequent API calls increases exponentially. If omitted, the default value is `25`.
+- `profile` (String) This is the AWS profile name as set in the shared credentials file.
+- `secret_key` (String) This is the AWS secret key. It must be provided, but it can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, or via a shared credentials file if `profile` is specified.
+- `shared_credentials_file` (String) This is the path to the shared credentials file. If this is not set and a profile is specified, `~/.aws/credentials` will be used.
+- `skip_credentials_validation` (Boolean) Skip the credentials validation via the STS API. Useful for AWS API implementations that do not have STS available or implemented.
+- `skip_metadata_api_check` (Boolean) Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. Setting to `true` prevents Terraform from authenticating via the Metadata API. You may need to use other authentication methods like static credentials, configuration variables, or environment variables.
+- `skip_requesting_account_id` (Boolean) Skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
+- `token` (String) Session token for validating temporary credentials. Typically provided after successful identity federation or Multi-Factor Authentication (MFA) login. With MFA login, this is the session token provided afterward, not the 6 digit MFA code used to get temporary credentials. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 
 <a id="nestedblock--assume_role"></a>
 ### Nested Schema for `assume_role`
 
 Optional:
 
-- **duration_seconds** (Number) Seconds to restrict the assume role session duration.
-- **external_id** (String) Unique identifier that might be required for assuming a role in another account.
-- **policy** (String) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
-- **policy_arns** (Set of String) Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
-- **role_arn** (String) Amazon Resource Name of an IAM Role to assume prior to making API calls.
-- **session_name** (String) Identifier for the assumed role session.
-- **tags** (Map of String) Assume role session tags.
-- **transitive_tag_keys** (Set of String) Assume role session tag keys to pass to any subsequent sessions.
+- `duration_seconds` (Number) Seconds to restrict the assume role session duration.
+- `external_id` (String) Unique identifier that might be required for assuming a role in another account.
+- `policy` (String) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+- `policy_arns` (Set of String) Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+- `role_arn` (String) Amazon Resource Name of an IAM Role to assume prior to making API calls.
+- `session_name` (String) Identifier for the assumed role session.
+- `tags` (Map of String) Assume role session tags.
+- `transitive_tag_keys` (Set of String) Assume role session tag keys to pass to any subsequent sessions.

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -40,6 +40,7 @@ resource "controltower_aws_account" "account" {
 
 ### Optional
 
+- `close_account_on_delete` (Boolean) If enabled, this will close the AWS account on resource deletion, beginning the 90-day suspension period. Otherwise, the account will just be unenrolled from Control Tower.
 - `id` (String) The ID of this resource.
 - `organizational_unit_on_delete` (String) Name of the Organizational Unit to which the account should be moved when the resource is deleted. If no value is provided, the account will not be moved.
 - `path_id` (String) Name of the path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths.

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -42,7 +42,7 @@ resource "controltower_aws_account" "account" {
 
 - `close_account_on_delete` (Boolean) If enabled, this will close the AWS account on resource deletion, beginning the 90-day suspension period. Otherwise, the account will just be unenrolled from Control Tower.
 - `id` (String) The ID of this resource.
-- `organizational_unit_on_delete` (String) Name of the Organizational Unit to which the account should be moved when the resource is deleted. If no value is provided, the account will not be moved.
+- `organizational_unit_id_on_delete` (String) ID of the Organizational Unit to which the account should be moved when the resource is deleted. If no value is provided, the account will not be moved.
 - `path_id` (String) Name of the path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths.
 - `provisioned_product_name` (String) Name of the service catalog product that is provisioned. Defaults to a slugified version of the account name.
 - `tags` (Map of String) Key-value map of resource tags for the account.

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -18,14 +18,12 @@ resource "controltower_aws_account" "account" {
   email               = "aws-admin@example.com"
   organizational_unit = "Sandbox"
 
+  organizational_unit_on_delete = "Suspended"
+
   sso {
     first_name = "John"
     last_name  = "Doe"
     email      = "john.doe@example.com"
-  }
-
-  lifecycle {
-    prevent_destroy = true
   }
 }
 ```
@@ -35,29 +33,30 @@ resource "controltower_aws_account" "account" {
 
 ### Required
 
-- **email** (String) Root email of the account.
-- **name** (String) Name of the account.
-- **organizational_unit** (String) Name of the Organizational Unit under which the account resides.
-- **sso** (Block List, Min: 1, Max: 1) Assigned SSO user settings. (see [below for nested schema](#nestedblock--sso))
+- `email` (String) Root email of the account.
+- `name` (String) Name of the account.
+- `organizational_unit` (String) Name of the Organizational Unit under which the account resides.
+- `sso` (Block List, Min: 1, Max: 1) Assigned SSO user settings. (see [below for nested schema](#nestedblock--sso))
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **path_id** (String) Name of the path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths.
-- **provisioned_product_name** (String) Name of the service catalog product that is provisioned. Defaults to a slugified version of the account name.
-- **tags** (Map of String) Key-value map of resource tags for the account.
+- `id` (String) The ID of this resource.
+- `organizational_unit_on_delete` (String) Name of the Organizational Unit to which the account should be moved when the resource is deleted. If no value is provided, the account will not be moved.
+- `path_id` (String) Name of the path identifier of the product. This value is optional if the product has a default path, and required if the product has more than one path. To list the paths for a product, use ListLaunchPaths.
+- `provisioned_product_name` (String) Name of the service catalog product that is provisioned. Defaults to a slugified version of the account name.
+- `tags` (Map of String) Key-value map of resource tags for the account.
 
 ### Read-Only
 
-- **account_id** (String) ID of the AWS account.
+- `account_id` (String) ID of the AWS account.
 
 <a id="nestedblock--sso"></a>
 ### Nested Schema for `sso`
 
 Required:
 
-- **email** (String) Email address of the user. If you use automatic provisioning this email address should already exist in AWS SSO.
-- **first_name** (String) First name of the user.
-- **last_name** (String) Last name of the user.
+- `email` (String) Email address of the user. If you use automatic provisioning this email address should already exist in AWS SSO.
+- `first_name` (String) First name of the user.
+- `last_name` (String) Last name of the user.
 
 

--- a/examples/resources/controltower_aws_account/resource.tf
+++ b/examples/resources/controltower_aws_account/resource.tf
@@ -3,13 +3,11 @@ resource "controltower_aws_account" "account" {
   email               = "aws-admin@example.com"
   organizational_unit = "Sandbox"
 
+  organizational_unit_on_delete = "Suspended"
+
   sso {
     first_name = "John"
     last_name  = "Doe"
     email      = "john.doe@example.com"
-  }
-
-  lifecycle {
-    prevent_destroy = true
   }
 }


### PR DESCRIPTION
This PR makes use of the newly released CloseAccount API from AWS, which finally allows us to automate the account lifecycle fully. It adds 2 options for handling this process according to AWS recommendations:

- `organizational_unit_id_on_delete` allows you to configure an OU id to which the account will be moved after it has been unmanaged from Control Tower
- `close_account_on_delete` allows you to close the account automatically on resource deletion

Both of these are optional, preserving the current behavior as default and therefore backwards compatibility. If an account was never successfully enrolled (e.g. when importing an existing account into Control Tower fails for some reason) it will not be moved to another OU or deleted on rollback to prevent unintended consequences.

Refs: SHUTTLE-662