### PR TITLE
feat: adds option to remove old user assignment on account update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ provider_installation {
 }
 
 ```
-Then you can test your changes in your terraform configuration by running `terraform init` in the directory where your terraform configuration is located. 
+Then you can test your changes in your terraform configuration by running `terraform init` (which will fail but that's expected) and then `terraform plan` in the directory where your terraform configuration is located. 
 
 Make sure to define the new version under the `required_providers` block. 
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,22 @@ You can test the provider locally before creating a PR by following the steps be
 
 ```sh
 $ make build # make sure to have the build version in the executable name as a postfix e.g. terraform-provider-controltower_v2.0.0
-$ mkdir -p ~/.terraform.d/plugins/registry.terraform.io/idealo/controltower/<some version>/darwin_arm64 # arch can be different depending on your system
-$ mv bin/terraform-provider-controltower_<some version> ~/.terraform.d/plugins/registry.terraform.io/idealo/controltower/<some version>/darwin_arm64 # some version should be the future version of the provider after the changes.
 ```
+create a `~/.terraformrc` file your home directory with the following content:
+```hcl
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/idealo/controltower" = "path-to-the-built-binary/terraform-provider-controltower"  # e.g /Users/username/repo/terraform-provider-controltower/bin/terraform-provider-controltower"
+  }
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
 
+```
 Then you can test your changes in your terraform configuration by running `terraform init` in the directory where your terraform configuration is located. 
 
 Make sure to define the new version under the `required_providers` block. 
 
-Alternatively, if you're using terraform 0.14 or later, you can make use of `dev_overrides` as described [here](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) and point the provider to your `~/.terraformrc`.
+A complete reference can be found [here](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers).

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -59,3 +59,9 @@ Required:
 - `email` (String) Email address of the user. If you use automatic provisioning this email address should already exist in AWS SSO.
 - `first_name` (String) First name of the user.
 - `last_name` (String) Last name of the user.
+
+Optional:
+
+- `instance_arn` (String) ARN of the SSO instance. Required if remove_account_assignment_on_update is enabled.
+- `principal_id` (String) Principal ID of the user. Required if remove_account_assignment_on_update is enabled.
+- `remove_account_assignment_on_update` (Boolean) If enabled, this will remove the account assignment for the old SSO user when the resource is updated.

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -13,7 +13,8 @@ Provides an AWS account resource via Control Tower.
 ## Example Usage
 
 ```terraform
-resource "controltower_aws_account" "account" {
+# Basic Example
+resource "controltower_aws_account" "basic_account_example" {
   name                = "Example Account"
   email               = "aws-admin@example.com"
   organizational_unit = "Sandbox"
@@ -24,6 +25,51 @@ resource "controltower_aws_account" "account" {
     first_name = "John"
     last_name  = "Doe"
     email      = "john.doe@example.com"
+  }
+}
+##########################################################################################################
+
+# Extended Example to handle account reassignment upon update
+locals {
+  username = "john.doe@example.de"
+}
+
+data "aws_ssoadmin_instances" "sso" {}
+
+# Normally AWSAdministratorAccess is the default permission set assigned to the account upon creation by Control Tower.
+data "aws_ssoadmin_permission_set" "permission" {
+
+  instance_arn = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
+  name         = "AWSAdministratorAccess"
+}
+
+data "aws_identitystore_user" "user" {
+
+  identity_store_id = tolist(data.aws_ssoadmin_instances.sso.identity_store_ids)[0]
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = local.username
+    }
+  }
+}
+
+resource "controltower_aws_account" "extended_example_account" {
+  name                = "Extended Example Account"
+  email               = local.username
+  organizational_unit = "Sandbox"
+
+  organizational_unit_id_on_delete = "ou-some-id"
+
+  sso {
+    first_name                          = "John"
+    last_name                           = "Doe"
+    email                               = "aws-admin@example.com"
+    instance_arn                        = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
+    principal_id                        = data.aws_identitystore_user.user.user_id
+    remove_account_assignment_on_update = true
+    permission_set_arn                  = data.aws_ssoadmin_permission_set.permission.arn
+
   }
 }
 ```
@@ -63,5 +109,6 @@ Required:
 Optional:
 
 - `instance_arn` (String) ARN of the SSO instance. Required if remove_account_assignment_on_update is enabled.
+- `permission_set_arn` (String) ARN of the permission set to be removed, normally it's the arn of AWSAdministratorAccess permission set. Required if remove_account_assignment_on_update is enabled.
 - `principal_id` (String) Principal ID of the user. Required if remove_account_assignment_on_update is enabled.
 - `remove_account_assignment_on_update` (Boolean) If enabled, this will remove the account assignment for the old SSO user when the resource is updated.

--- a/examples/resources/controltower_aws_account/resource.tf
+++ b/examples/resources/controltower_aws_account/resource.tf
@@ -1,5 +1,4 @@
-# Basic Example
-resource "controltower_aws_account" "basic_account_example" {
+resource "controltower_aws_account" "account" {
   name                = "Example Account"
   email               = "aws-admin@example.com"
   organizational_unit = "Sandbox"
@@ -10,50 +9,5 @@ resource "controltower_aws_account" "basic_account_example" {
     first_name = "John"
     last_name  = "Doe"
     email      = "john.doe@example.com"
-  }
-}
-##########################################################################################################
-
-# Extended Example to handle account reassignment upon update
-locals {
-  username = "john.doe@example.de"
-}
-
-data "aws_ssoadmin_instances" "sso" {}
-
-# Normally AWSAdministratorAccess is the default permission set assigned to the account upon creation by Control Tower.
-data "aws_ssoadmin_permission_set" "permission" {
-
-  instance_arn = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
-  name         = "AWSAdministratorAccess"
-}
-
-data "aws_identitystore_user" "user" {
-
-  identity_store_id = tolist(data.aws_ssoadmin_instances.sso.identity_store_ids)[0]
-  alternate_identifier {
-    unique_attribute {
-      attribute_path  = "UserName"
-      attribute_value = local.username
-    }
-  }
-}
-
-resource "controltower_aws_account" "extended_example_account" {
-  name                = "Extended Example Account"
-  email               = local.username
-  organizational_unit = "Sandbox"
-
-  organizational_unit_id_on_delete = "ou-some-id"
-
-  sso {
-    first_name                          = "John"
-    last_name                           = "Doe"
-    email                               = "aws-admin@example.com"
-    instance_arn                        = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
-    principal_id                        = data.aws_identitystore_user.user.user_id
-    remove_account_assignment_on_update = true
-    permission_set_arn                  = data.aws_ssoadmin_permission_set.permission.arn
-
   }
 }

--- a/examples/resources/controltower_aws_account/resource.tf
+++ b/examples/resources/controltower_aws_account/resource.tf
@@ -1,4 +1,5 @@
-resource "controltower_aws_account" "account" {
+# Basic Example
+resource "controltower_aws_account" "basic_account_example" {
   name                = "Example Account"
   email               = "aws-admin@example.com"
   organizational_unit = "Sandbox"
@@ -9,5 +10,50 @@ resource "controltower_aws_account" "account" {
     first_name = "John"
     last_name  = "Doe"
     email      = "john.doe@example.com"
+  }
+}
+##########################################################################################################
+
+# Extended Example to handle account reassignment upon update
+locals {
+  username = "john.doe@example.de"
+}
+
+data "aws_ssoadmin_instances" "sso" {}
+
+# Normally AWSAdministratorAccess is the default permission set assigned to the account upon creation by Control Tower.
+data "aws_ssoadmin_permission_set" "permission" {
+
+  instance_arn = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
+  name         = "AWSAdministratorAccess"
+}
+
+data "aws_identitystore_user" "user" {
+
+  identity_store_id = tolist(data.aws_ssoadmin_instances.sso.identity_store_ids)[0]
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = local.username
+    }
+  }
+}
+
+resource "controltower_aws_account" "extended_example_account" {
+  name                = "Extended Example Account"
+  email               = local.username
+  organizational_unit = "Sandbox"
+
+  organizational_unit_id_on_delete = "ou-some-id"
+
+  sso {
+    first_name                          = "John"
+    last_name                           = "Doe"
+    email                               = "aws-admin@example.com"
+    instance_arn                        = tolist(data.aws_ssoadmin_instances.sso.arns)[0]
+    principal_id                        = data.aws_identitystore_user.user.user_id
+    remove_account_assignment_on_update = true
+    permission_set_arn                  = data.aws_ssoadmin_permission_set.permission.arn
+
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.48
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.8
+	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8
 	github.com/aws/smithy-go v1.22.1
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.32.7
 	github.com/aws/aws-sdk-go-v2/config v1.28.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.48
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.8
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8
@@ -30,7 +31,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.8 h1:uDR8FMmsEd/g+eihj
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.8/go.mod h1:8ugnqCHkdv41d2Mo5F/mdPtaXauABVDYL3kV9U7LNbM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 h1:CvuUmnXI7ebaUAhbJcDy9YQx8wHR69eZ9I7q5hszt/g=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.8/go.mod h1:XDeGv1opzwm8ubxddF0cgqkZWsyOtw4lr6dxwmb6YQg=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8 h1:nCDnD8rVurC8E43scFw1lDHBRi1aSxAyOgfDHauTUsg=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8/go.mod h1:gs/HuXKm8GZigCov15NZ9pt/u9EhD5gij4/uAEEnlJM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.7 h1:F2rBfNAL5UyswqoeWv9zs74N/NanhK16ydHW1pahX6E=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.7/go.mod h1:JfyQ0g2JG8+Krq0EuZNnRwX0mU0HrwY/tG6JNfcqh4k=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.3 h1:Xgv/hyNgvLda/M9l9qxXc4UFSgppnRczLxlMs5Ae/QY=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 h1:zXFLuEuMMUOvEARXFU
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26/go.mod h1:3o2Wpy0bogG1kyOPrgkXA8pgIfEEv0+m19O9D5+W8y8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8 h1:Lg2UE1jqXgvhaWnHbnUuFdFORQLxKbJY4TSU87q6zGU=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8/go.mod h1:M5UW9CJQV78QiCxGihlGzwRbAD4B+fJf3y8yAij62Y0=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 h1:iXtILhvDxB6kPvEXgsDhGaZCSC6LQET5ZHSdJozeI0Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1/go.mod h1:9nu0fVANtYiAePIBh2/pFUSwtJ402hLnp854CNoDOeE=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 h1:8eUsivBQzZHqe/3FE+cqwfH+0p5Jo8PFM/QYQSmeZ+M=

--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -79,6 +79,7 @@ func resourceAWSAccount() *schema.Resource {
 							Description: "ARN of the SSO instance. Required if remove_account_assignment_on_update is enabled.",
 							Type:        schema.TypeString,
 							Required:    false,
+							Optional:    true,
 						},
 						"remove_account_assignment_on_update": {
 							Description: "If enabled, this will remove the account assignment for the old SSO user when the resource is updated.",
@@ -90,6 +91,7 @@ func resourceAWSAccount() *schema.Resource {
 							Description: "Principal ID of the user. Required if remove_account_assignment_on_update is enabled.",
 							Type:        schema.TypeString,
 							Required:    false,
+							Optional:    true,
 						},
 					},
 				},

--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -452,8 +452,9 @@ func updateAccountAssignment(ctx context.Context, d *schema.ResourceData, ssoadm
 	sso := d.Get("sso").([]interface{})[0].(map[string]interface{})
 	instanceArn := sso["instance_arn"].(string)
 	oldPrincipalId := oldSSOMap["principal_id"].(string)
+	newPrincipalId := newSSOMap["principal_id"].(string)
 
-	if oldEmail != newEmail && oldPrincipalId != "" && instanceArn != "" {
+	if oldEmail != newEmail && oldPrincipalId != newPrincipalId && oldPrincipalId != "" && instanceArn != "" {
 
 		_, err := ssoadmincon.DeleteAccountAssignment(ctx, &ssoadmin.DeleteAccountAssignmentInput{
 			InstanceArn:   &instanceArn,

--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -354,6 +354,7 @@ func resourceAWSAccountUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 	scconn := servicecatalog.NewFromConfig(cfg)
 	organizationsconn := organizations.NewFromConfig(cfg)
+	sso := d.Get("sso").([]interface{})[0].(map[string]interface{})
 
 	if d.HasChangesExcept("tags", "organizational_unit_id_on_delete", "close_account_on_delete") {
 		productId, artifactId, err := findServiceCatalogAccountProductId(ctx, scconn)
@@ -365,7 +366,6 @@ func resourceAWSAccountUpdate(ctx context.Context, d *schema.ResourceData, m int
 		name := d.Get("name").(string)
 		email := d.Get("email").(string)
 		ou := d.Get("organizational_unit").(string)
-		sso := d.Get("sso").([]interface{})[0].(map[string]interface{})
 
 		// Create a new parameters struct.
 		params := &servicecatalog.UpdateProvisionedProductInput{
@@ -429,7 +429,6 @@ func resourceAWSAccountUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
-	sso := d.Get("sso").([]interface{})[0].(map[string]interface{})
 	isRemoveAccountAssignmentOnUpdate := sso["remove_account_assignment_on_update"].(bool)
 
 	if d.HasChange("sso") && isRemoveAccountAssignmentOnUpdate {


### PR DESCRIPTION
The default behaviour in AWS Control Tower Account Factory when updating an account with a new user email address does not drop the old user assignment, but rather just assigns the new user to the account. AWS support confirmed that this behaviour is by design and works as intended. An excerpt of the response we received was "_This design allows for scenarios where you might want to maintain access for multiple users or ensure business continuity during transitions._" 

Since this behaviour might not always be desired, this PR adds the possibility to optionally drop the old user assignment after updating the provisioned product successfully. It uses the [ssoadmin](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssoadmin) to achieve that.

The default behaviour is not affected and the new behaviour only works when `remove_account_assignment_on_update` is set to `true` along with filling all the other attributes under the `sso` object.

A complete example can be found in the docs as a part of this PR.

Should solve https://github.com/idealo/terraform-provider-controltower/issues/217 