### PR TITLE
chore(CCORE-6): Update CODEOWNERS to reflect cloud-core team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @idealo/engineering-experience
+* @idealo/cloud-core


### PR DESCRIPTION
## Summary
This pull request updates the CODEOWNERS file to reflect the team ownership transition from engineering-experience to cloud-core team.

## Changes Made
- Updated CODEOWNERS file to replace @idealo/engineering-experience with @idealo/cloud-core
- Cloud-core team has been granted admin permissions to this repository
- All existing formatting and other team references have been preserved

## Context
This change is part of the team restructuring initiative where cloud-core team is taking ownership of repositories previously managed by engineering-experience team.

The cloud-core team now has admin access to this repository and will be responsible for code ownership and reviews going forward.