### PR TITLE
chore: Update catalog-info to reflect cloud-core team ownership

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,5 +16,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: group:engineering-experience
+  owner: group:cloud-core
   system: organization


### PR DESCRIPTION
## Summary
This pull request updates catalog-info file to reflect the team ownership transition from engineering-experience to cloud-core team.

## Changes Made
- catalog-info file (1 replacements)

**Total replacements made: 1**

## Context
This is a one-time fix to update Backstage metadata after the team transition was completed. The engineering-experience team ownership was already transferred to cloud-core team, but catalog-info files still contained old team references.

The cloud-core team now manages these repositories and their Backstage metadata should reflect this change.